### PR TITLE
Serialise Merkle trees to blobs when building docker image

### DIFF
--- a/.github/workflows/build_api.yaml
+++ b/.github/workflows/build_api.yaml
@@ -1,4 +1,4 @@
-name: Kamino 
+name: API
 
 on:
   push:
@@ -48,7 +48,7 @@ jobs:
           secrets: |
             "aws_access_key_id=${{ secrets.AWS_ACCESS_KEY_ID_DISTRIBUTOR_BUILD }}"
             "aws_secret_access_key=${{ secrets.AWS_SECRET_ACCESS_KEY_DISTRIBUTOR_BUILD }}"
-          file: ./Dockerfile
+          file: ./api/Dockerfile
           tags: hubbleprotocol/kamino-airdrop-api:${{ steps.set_versions.outputs.build_version }}
           push: true
           target: runtime

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -1,0 +1,40 @@
+name: Rust
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: install essential
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config build-essential libudev-dev
+      - uses: dtolnay/rust-toolchain@1.73.0
+        with:
+          components: rustfmt
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions-rs/cargo@v1
+        name: Rust format
+        with:
+          toolchain: nightly
+          command: fmt
+          args: --all -- --check
+      - uses: actions-rs/clippy-check@v1
+        name: Clippy
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,4 @@ keys/
 list/
 keys/**/*.json
 kmno_trees/
+kmno_tree_blobs/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2111,8 +2111,9 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jito-merkle-tree"
-version = "0.0.1"
+version = "0.1.0-SNAPSHOT"
 dependencies = [
+ "bincode",
  "csv",
  "fast-math",
  "hex",
@@ -2128,7 +2129,7 @@ dependencies = [
 
 [[package]]
 name = "jito-merkle-verify"
-version = "0.0.1"
+version = "0.1.0-SNAPSHOT"
 dependencies = [
  "solana-program",
 ]
@@ -2168,7 +2169,7 @@ dependencies = [
 
 [[package]]
 name = "jup-scripts"
-version = "0.0.1"
+version = "0.1.0-SNAPSHOT"
 dependencies = [
  "anchor-client",
  "anchor-lang",
@@ -2193,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "kamino-airdrop-api"
-version = "0.0.1"
+version = "0.1.0-SNAPSHOT"
 dependencies = [
  "anchor-lang",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ incremental = false
 codegen-units = 1
 
 [workspace.package]
-version = "0.0.1"
+version = "0.1.0-SNAPSHOT"
 authors = ["Jito Labs <team@jito.wtf>"]
 repository = ""
 homepage = "jito.wtf"
@@ -31,6 +31,7 @@ anchor-lang = "0.28.0"
 anchor-spl = "0.28.0"
 anchor-client = "0.28.0"
 axum = "0.6.2"
+bincode = "1.3.3"
 bytemuck = "1.14.0"
 clap = { version = "3.2.25", features = ["derive", "env"] }
 csv = "1.3.0"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: build-docker-api
+
+build-docker-api:
+	DOCKER_BUILDKIT=1 docker build --target runtime . -f ./api/Dockerfile -t hubbleprotocol/kamino-airdrop-api:latest --secret id=aws_access_key_id,env=AWS_ACCESS_KEY_ID --secret id=aws_secret_access_key,env=AWS_SECRET_ACCESS_KEY

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -16,6 +16,9 @@ WORKDIR distributor
 
 FROM chef AS prepare
 
+ENV RUST_BACKTRACE=full
+ENV RUST_LOG=info
+
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
@@ -27,15 +30,16 @@ RUN --mount=type=secret,id=aws_access_key_id \
     --mount=type=secret,id=aws_secret_access_key \
     AWS_ACCESS_KEY_ID=$(cat /run/secrets/aws_access_key_id) \
     AWS_SECRET_ACCESS_KEY=$(cat /run/secrets/aws_secret_access_key) \
-    aws s3 sync s3://k8s.hubbleprotocol.io-kamino-distributor/Gg5Y6LvxzDMVxArK7mcGM2vB4fiwcvUnYnviLM2uqjVY ./kmno_trees
+    aws s3 sync s3://k8s.hubbleprotocol.io-kamino-distributor/Gg5Y6LvxzDMVxArK7mcGM2vB4fiwcvUnYnviLM2uqjVY ./kmno_trees --exclude ".DS_Store" --include "*.json"
 
 COPY --from=prepare /distributor/recipe.json recipe.json
 
 # Build dependencies - this is the caching Docker layer!
-RUN cargo chef cook --release --bin kamino-airdrop-api --recipe-path recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
 
 # Build application
 COPY . .
+RUN  cargo run --bin cli  create-merkle-tree-blob --json-path ./kmno_trees --merkle-tree-path ./kmno_tree_blobs
 RUN cargo build --release --bin kamino-airdrop-api --locked
 
 FROM debian:bullseye-slim AS runtime
@@ -44,9 +48,9 @@ RUN apt-get update && apt-get install -y libssl1.1 libpq-dev ca-certificates && 
 
 COPY --from=build /distributor/target/release/kamino-airdrop-api ./
 
-COPY --from=build /distributor/kmno_trees ./distributor/kmno_trees/
+COPY --from=build /distributor/kmno_tree_blobs ./distributor/kmno_trees/
 
-RUN rm ./distributor/kmno_trees/.DS_Store
+ENV MERKLE_TREE_PATH=./distributor/kmno_trees/
 
 ENTRYPOINT ["./kamino-airdrop-api"]
 

--- a/api/load_test.sh
+++ b/api/load_test.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+export base_url="https://api.dev.kamino.finance/distributor/user"
+
+max_concurrency=10
+
+ORIGINAL_DIR="$(pwd)"
+SCRIPT_DIR="$( dirname "${BASH_SOURCE[0]}" )"
+cd $SCRIPT_DIR/..
+
+function cleanup() {
+  cd $ORIGINAL_DIR
+  set +e
+}
+
+trap cleanup EXIT
+
+# Read the CSV file and skip the header line
+tail -n +2 list/kmno_allocation.csv | awk -F, '{print $1}' | \
+xargs -n1 -S1024 -P$max_concurrency -I {} sh -c '{
+    # Make a request and capture only the HTTP status code
+    http_status=$(curl -s -o /dev/null -w "%{http_code}" "${base_url}/{}")
+    if [ "$http_status" != "200" ]; then
+        echo "Error for pubkey {}: HTTP Status: $http_status"
+    fi
+}'
+
+echo "Load testing complete."

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -70,8 +70,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
                     AirdropMerkleTree::new_from_blob(&single_tree_path)?
                 } else if ext == "json" {
                     AirdropMerkleTree::new_from_file(&single_tree_path)?
-                }
-                else {
+                } else {
                     println!("Skipping Merkle tree file {:?} in {:?} because it is not '.json' or '.bin' type", single_tree_path, &args.merkle_tree_path);
                     continue;
                 }
@@ -102,7 +101,10 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         for node in single_tree.tree_nodes.iter() {
             tree.insert(node.claimant, (distributor_pubkey, node.clone()));
         }
-        println!("Loaded {} {:?}", single_tree.airdrop_version, single_tree_path);
+        println!(
+            "Loaded {} {:?}",
+            single_tree.airdrop_version, single_tree_path
+        );
     }
 
     println!("Loaded {} trees", distributors.len());

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -3,7 +3,6 @@ mod router;
 
 use std::{
     collections::HashMap, fmt::Debug, fs, net::SocketAddr, path::PathBuf, str::FromStr, sync::Arc,
-    thread, time,
 };
 
 use clap::Parser;
@@ -63,10 +62,22 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let mut max_num_nodes = 0u64;
     let mut max_total_claim = 0u64;
     let mut distributors = vec![];
-    let one_sec = time::Duration::from_millis(1000);
     for file in paths {
         let single_tree_path = file.path();
-        let single_tree = AirdropMerkleTree::new_from_file(&single_tree_path)?;
+        let single_tree = match single_tree_path.extension() {
+            Some(ext) => {
+                if ext == "bin" {
+                    AirdropMerkleTree::new_from_blob(&single_tree_path)?
+                } else if ext == "json" {
+                    AirdropMerkleTree::new_from_file(&single_tree_path)?
+                }
+                else {
+                    println!("Skipping Merkle tree file {:?} in {:?} because it is not '.json' or '.bin' type", single_tree_path, &args.merkle_tree_path);
+                    continue;
+                }
+            }
+            None => continue,
+        };
 
         let (distributor_pubkey, _bump) = get_merkle_distributor_pda(
             &args.program_id,
@@ -91,11 +102,10 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         for node in single_tree.tree_nodes.iter() {
             tree.insert(node.claimant, (distributor_pubkey, node.clone()));
         }
-        println!("done {}", single_tree.airdrop_version);
-        thread::sleep(one_sec);
+        println!("Loaded {} {:?}", single_tree.airdrop_version, single_tree_path);
     }
 
-    println!("Done all tree");
+    println!("Loaded {} trees", distributors.len());
 
     distributors.sort_unstable_by(|a, b| a.airdrop_version.cmp(&b.airdrop_version));
 

--- a/cli/src/bin/cli.rs
+++ b/cli/src/bin/cli.rs
@@ -102,6 +102,8 @@ pub enum Commands {
     Clawback(ClawbackArgs),
     /// Create a Merkle tree, given a CSV of recipients
     CreateMerkleTree(CreateMerkleTreeArgs),
+    /// Serialize a JSON Merkle tree file into an architecture-specific blob
+    CreateMerkleTreeBlob(CreateMerkleTreeBlobArgs),
     SetAdmin(SetAdminArgs),
 
     SetEnableSlot(SetEnableSlotArgs),
@@ -252,6 +254,17 @@ pub struct CreateMerkleTreeArgs {
     pub amount: f64,
     #[clap(long, env)]
     pub decimals: u32,
+}
+
+#[derive(Parser, Debug)]
+pub struct CreateMerkleTreeBlobArgs {
+    /// JSON input path
+    #[clap(long, env)]
+    pub json_path: PathBuf,
+
+    /// Merkle tree out path
+    #[clap(long, env)]
+    pub merkle_tree_path: PathBuf,
 }
 
 #[derive(Parser, Debug)]
@@ -440,7 +453,7 @@ pub struct ViewDistributorsArgs {
     pub to_version: u64,
 }
 
-fn main() {
+fn main() -> Result<()> {
     let args = Args::parse();
 
     match &args.command {
@@ -459,6 +472,9 @@ fn main() {
         Commands::Clawback(clawback_args) => process_clawback(&args, clawback_args),
         Commands::CreateMerkleTree(merkle_tree_args) => {
             process_create_merkle_tree(merkle_tree_args);
+        }
+        Commands::CreateMerkleTreeBlob(merkle_tree_blob_args) => {
+            process_create_merkle_tree_blob(merkle_tree_blob_args)?;
         }
         Commands::SetAdmin(set_admin_args) => {
             process_set_admin(&args, set_admin_args);
@@ -495,7 +511,8 @@ fn main() {
         Commands::SetClawbackReceiver(set_clawback_receiver_argrs) => {
             process_set_clawback_receiver(&args, set_clawback_receiver_argrs)
         }
-    }
+    };
+    Ok(())
 }
 
 fn check_distributor_onchain_matches(

--- a/cli/src/bin/instructions/mod.rs
+++ b/cli/src/bin/instructions/mod.rs
@@ -10,6 +10,8 @@ pub mod process_clawback;
 pub use process_clawback::*;
 pub mod process_create_merkle_tree;
 pub use process_create_merkle_tree::*;
+pub mod process_create_merkle_tree_blob;
+pub use process_create_merkle_tree_blob::*;
 pub mod process_set_admin;
 pub use process_set_admin::*;
 pub mod process_set_enable_slot;

--- a/cli/src/bin/instructions/process_claim_from_api.rs
+++ b/cli/src/bin/instructions/process_claim_from_api.rs
@@ -11,8 +11,8 @@ pub fn process_claim_from_api(args: &Args, claim_args: &ClaimFromApiArgs) {
     let kv_proof: UserProof = reqwest::blocking::get(format!(
         "{}/{}/{}",
         claim_args.root_api,
-        args.mint.to_string(),
-        claimant.to_string()
+        args.mint,
+        claimant
     ))
     .unwrap()
     .json()
@@ -84,7 +84,7 @@ pub fn process_claim_from_api(args: &Args, claim_args: &ClaimFromApiArgs) {
                 &claimant_ata,
                 &destination_ata,
                 &claimant,
-                &vec![],
+                &[],
                 kv_proof.amount,
             )
             .unwrap(),

--- a/cli/src/bin/instructions/process_claim_from_api.rs
+++ b/cli/src/bin/instructions/process_claim_from_api.rs
@@ -10,9 +10,7 @@ pub fn process_claim_from_api(args: &Args, claim_args: &ClaimFromApiArgs) {
 
     let kv_proof: UserProof = reqwest::blocking::get(format!(
         "{}/{}/{}",
-        claim_args.root_api,
-        args.mint,
-        claimant
+        claim_args.root_api, args.mint, claimant
     ))
     .unwrap()
     .json()

--- a/cli/src/bin/instructions/process_create_merkle_tree.rs
+++ b/cli/src/bin/instructions/process_create_merkle_tree.rs
@@ -10,7 +10,7 @@ pub fn process_create_merkle_tree(merkle_tree_args: &CreateMerkleTreeArgs) {
 
     let base_path = &merkle_tree_args.merkle_tree_path;
     let mut index = 0;
-    while csv_entries.len() > 0 {
+    while !csv_entries.is_empty() {
         let last_index = max_nodes_per_tree.min(csv_entries.len());
         let sub_tree = csv_entries[0..last_index].to_vec();
         csv_entries = csv_entries[last_index..csv_entries.len()].to_vec();

--- a/cli/src/bin/instructions/process_create_merkle_tree_blob.rs
+++ b/cli/src/bin/instructions/process_create_merkle_tree_blob.rs
@@ -1,0 +1,35 @@
+use crate::*;
+
+pub fn process_create_merkle_tree_blob(merkle_tree_blob_args: &CreateMerkleTreeBlobArgs) -> Result<()> {
+
+    let paths: Vec<_> = fs::read_dir(&merkle_tree_blob_args.json_path)
+        .unwrap()
+        .map(|r| r.unwrap())
+        .collect();
+
+    // create merkle tree folder if not existed
+    fs::create_dir_all(merkle_tree_blob_args.merkle_tree_path.clone()).unwrap();
+
+    for file in paths {
+        let single_tree_path = file.path();
+        let (fname, single_tree) = match single_tree_path.extension() {
+            Some(ext) => {
+                if ext == "bin" {
+                    continue;
+                } else {
+                    let fname = single_tree_path.file_stem().unwrap().to_str().unwrap();
+                    (fname, AirdropMerkleTree::new_from_file(&single_tree_path)?)
+                }
+            }
+            None => continue,
+        };
+        let base_path_clone = merkle_tree_blob_args.merkle_tree_path.clone();
+        let path = base_path_clone
+            .as_path()
+            .join(format!("{fname}.bin"));
+        single_tree.write_blob_to_file(&path)?;
+        println!("Wrote blob to {path:?}");
+    }
+
+    Ok(())
+}

--- a/cli/src/bin/instructions/process_create_merkle_tree_blob.rs
+++ b/cli/src/bin/instructions/process_create_merkle_tree_blob.rs
@@ -1,7 +1,8 @@
 use crate::*;
 
-pub fn process_create_merkle_tree_blob(merkle_tree_blob_args: &CreateMerkleTreeBlobArgs) -> Result<()> {
-
+pub fn process_create_merkle_tree_blob(
+    merkle_tree_blob_args: &CreateMerkleTreeBlobArgs,
+) -> Result<()> {
     let paths: Vec<_> = fs::read_dir(&merkle_tree_blob_args.json_path)
         .unwrap()
         .map(|r| r.unwrap())
@@ -24,9 +25,7 @@ pub fn process_create_merkle_tree_blob(merkle_tree_blob_args: &CreateMerkleTreeB
             None => continue,
         };
         let base_path_clone = merkle_tree_blob_args.merkle_tree_path.clone();
-        let path = base_path_clone
-            .as_path()
-            .join(format!("{fname}.bin"));
+        let path = base_path_clone.as_path().join(format!("{fname}.bin"));
         single_tree.write_blob_to_file(&path)?;
         println!("Wrote blob to {path:?}");
     }

--- a/cli/src/bin/instructions/process_generate_kv_proof.rs
+++ b/cli/src/bin/instructions/process_generate_kv_proof.rs
@@ -41,7 +41,7 @@ pub fn process_generate_kv_proof(args: &Args, generate_kv_proof_args: &GenerateK
         );
 
         for node in merkle_tree.tree_nodes.iter() {
-            let user_pk = Pubkey::from(node.claimant);
+            let user_pk = node.claimant;
             proofs.insert(
                 user_pk.to_string(),
                 KvProof {
@@ -64,7 +64,7 @@ pub fn process_generate_kv_proof(args: &Args, generate_kv_proof_args: &GenerateK
             merkle_tree.airdrop_version
         );
     }
-    if proofs.len() > 0 {
+    if !proofs.is_empty() {
         write_to_file(generate_kv_proof_args, file_index, &proofs);
     }
 }

--- a/cli/src/bin/instructions/process_new_distributor.rs
+++ b/cli/src/bin/instructions/process_new_distributor.rs
@@ -74,7 +74,7 @@ fn create_new_distributor(args: &Args, new_distributor_args: &NewDistributorArgs
                 new_distributor_args,
                 keypair.pubkey(),
                 base.pubkey(),
-                &args,
+                args,
             ).expect("merkle root on-chain does not match provided arguments! Confirm admin and clawback parameters to avoid loss of funds!");
             continue;
         }

--- a/cli/src/bin/instructions/process_send.rs
+++ b/cli/src/bin/instructions/process_send.rs
@@ -126,7 +126,7 @@ pub fn process_mass_send(args: &Args, mass_send_args: &MassSendArgs) {
         index += 1;
     }
 
-    if batch_addresses.len() > 0 {
+    if !batch_addresses.is_empty() {
         wrap_batch_addresses.push(batch_addresses.clone());
     }
     println!(
@@ -182,17 +182,17 @@ pub fn process_resend(args: &Args, resend_args: &ResendSendArgs) {
         ) {
             Ok(value) => {
                 let mut should_resend = false;
-                if value.is_none() {
-                    println!("{} is not existed resend", signature);
-                    should_resend = true;
-                } else {
-                    match value.unwrap() {
+                if let Some(v) = value {
+                    match v {
                         Ok(_) => {}
                         Err(err) => {
                             println!("{} is error {}", signature, err);
                             should_resend = true;
                         }
                     }
+                } else {
+                    println!("{} is not existed resend", signature);
+                    should_resend = true;
                 }
 
                 if should_resend {

--- a/cli/src/bin/instructions/process_set_enable_slot_by_time.rs
+++ b/cli/src/bin/instructions/process_set_enable_slot_by_time.rs
@@ -128,12 +128,12 @@ pub fn get_average_slot_time(client: &RpcClient) -> Result<u64> {
 
     let mut total_time = 0;
     for sample in samples.iter() {
-        total_time = total_time + sample.sample_period_secs as u64 * 1000 / sample.num_slots;
+        total_time += sample.sample_period_secs as u64 * 1000 / sample.num_slots;
     }
 
     let average_time = total_time / num_samples;
     // sanity check
-    if average_time < DEFAULT_MS_PER_SLOT / 2 || average_time > DEFAULT_MS_PER_SLOT * 2 {
+    if !(DEFAULT_MS_PER_SLOT / 2..=DEFAULT_MS_PER_SLOT * 2).contains(&average_time) {
         println!("average_time is passed sanity check {}", average_time);
         return Ok(DEFAULT_MS_PER_SLOT);
     }

--- a/merkle-tree/Cargo.toml
+++ b/merkle-tree/Cargo.toml
@@ -4,6 +4,7 @@ version = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+bincode = { workspace = true }
 csv = { workspace = true }
 fast-math = { workspace = true }
 indexmap = { workspace = true }

--- a/merkle-tree/src/airdrop_merkle_tree.rs
+++ b/merkle-tree/src/airdrop_merkle_tree.rs
@@ -120,7 +120,7 @@ impl AirdropMerkleTree {
         Ok(tree)
     }
 
-    /// Load a serialized merkle tree from file path
+    /// Load a json serialized merkle tree from file path
     pub fn new_from_file(path: &PathBuf) -> Result<Self> {
         let file = File::open(path)?;
         let reader = BufReader::new(file);
@@ -129,11 +129,27 @@ impl AirdropMerkleTree {
         Ok(tree)
     }
 
-    /// Write a merkle tree to a filepath
+    /// Write a json-serialised merkle tree to a filepath
     pub fn write_to_file(&self, path: &PathBuf) {
         let serialized = serde_json::to_string_pretty(&self).unwrap();
         let mut file = File::create(path).unwrap();
         file.write_all(serialized.as_bytes()).unwrap();
+    }
+
+    /// Load a blob serialized merkle tree from file path
+    pub fn new_from_blob(path: &PathBuf) -> Result<Self> {
+        let file = File::open(path)?;
+        let mut reader = BufReader::new(file);
+        let tree: AirdropMerkleTree = bincode::deserialize_from(&mut reader).unwrap();
+        Ok(tree)
+    }
+
+    /// Write a blob merkle tree to a filepath
+    pub fn write_blob_to_file(&self, path: &PathBuf) -> Result<()> {
+        let encoded: Vec<u8> = bincode::serialize(&self).unwrap();
+        let mut file = File::create(path)?;
+        file.write_all(&encoded)?;
+        Ok(())
     }
 
     pub fn get_node(&self, claimant: &Pubkey) -> TreeNode {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.73.0"
+components = ["clippy", "rustfmt"]
+targets = []


### PR DESCRIPTION
- Serialise Merkle trees to blobs when building docker image
- Add load test
- FIx clippy

Before

```sh
tree_0.json 112M 
tree_1.json 112M 
tree_10.json 112M 
tree_11.json 112M 
tree_12.json 112M 
tree_13.json 112M 
tree_14.json 112M 
tree_15.json 111M 
tree_2.json 112M 
tree_3.json 112M 
tree_4.json 112M 
tree_5.json 112M 
tree_6.json 112M 
tree_7.json 112M 
tree_8.json 112M 
tree_9.json 112M
```

After:

```sh
tree_0.bin 7.6M 
tree_1.bin 7.6M 
tree_10.bin 7.6M 
tree_11.bin 7.6M 
tree_12.bin 7.6M 
tree_13.bin 7.6M 
tree_14.bin 7.6M 
tree_15.bin 7.6M 
tree_2.bin 7.6M 
tree_3.bin 7.6M 
tree_4.bin 7.6M 
tree_5.bin 7.6M 
tree_6.bin 7.6M 
tree_7.bin 7.6M 
tree_8.bin 7.6M 
tree_9.bin 7.6M 
```

Before:

REPOSITORY                                       TAG       IMAGE ID       CREATED             SIZE
hubbleprotocol/kamino-airdrop-api                latest    b02e77bc12ee   8 minutes ago       **1.96GB**

After:

REPOSITORY                                       TAG       IMAGE ID       CREATED          SIZE
hubbleprotocol/kamino-airdrop-api                latest    c354d9488d62   26 minutes ago   **210MB**

